### PR TITLE
fix: Remove totalFeeCost decimals

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -538,7 +538,7 @@ export default {
       const networkFee = this.estimatedGasInCAKE
       
       const composedInterestRate = periodInterestRate ** periodCount
-      const totalFeeCost = networkFee * periodCount
+      const totalFeeCost = Math.round(networkFee * periodCount)
       
       const result = (investedAmount * composedInterestRate - totalFeeCost - investedAmount)
       


### PR DESCRIPTION
Error: [number-to-bn] while converting number "1.1" to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported.